### PR TITLE
Added support for 4.06.1 and fixed build issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OCAML_OPTS=-w,+a-3-4-32..39,-warn-error,+a,-strict-sequence,-noautolink
+OCAML_OPTS=-w,+a-3-4-32..39-58,-warn-error,+a,-strict-sequence,-noautolink
 
 PROGRAM=caradoc
 
@@ -41,25 +41,16 @@ $(PROGRAM): main.native
 debug-menhir:
 	ocamlbuild -use-ocamlfind -menhir "menhir --dump --trace" src/main.native
 
-main.native:
-	ocamlbuild -cflags $(OCAML_OPTS) -use-ocamlfind src/main.native
+main.byte main.native:
+	ocamlbuild -cflags $(OCAML_OPTS) -use-ocamlfind src/$@
 	rm -f $@
 	ln -s _build/src/$@
 
-main.byte:
-	ocamlbuild -cflags $(OCAML_OPTS) -use-ocamlfind src/main.byte
+unit.byte unit.native:
+	ocamlbuild -cflags $(OCAML_OPTS) -tag-line "true: package(oUnit)" -use-ocamlfind -no-hygiene test/$@
 	rm -f $@
-	ln -s _build/src/$@
+	ln -s _build/test/$@
 
-unit.native:
-	ocamlbuild -cflags $(OCAML_OPTS) -build-dir "_build.test" -tag-line "true: package(oUnit)" -use-ocamlfind test/unit.native
-	rm -f $@
-	ln -s _build.test/test/$@
-
-unit.byte:
-	ocamlbuild -cflags $(OCAML_OPTS) -build-dir "_build.test" -tag-line "true: package(oUnit)" -use-ocamlfind test/unit.byte
-	rm -f $@
-	ln -s _build.test/test/$@
 
 %.indentml: %.ml
 	ocp-indent -i $<
@@ -105,7 +96,7 @@ tmpfolder:
 
 clean:
 	rm -f $(PROGRAM) *.native *.byte
-	rm -Rf _build _build.test
+	rm -Rf _build
 	rm -f oUnit-anon.cache
 	rm -Rf tmp
 

--- a/src/crypto/rc4.ml
+++ b/src/crypto/rc4.ml
@@ -43,7 +43,7 @@ module RC4 = struct
     {s = s; i = 0; j = 0;}
 
   let crypt (key : string) (src : string) : string =
-    let dst = String.copy src in
+    let dst = Bytes.of_string src in
     let x = init key in
 
     for a = 0 to (String.length src) - 1 do
@@ -51,9 +51,9 @@ module RC4 = struct
       x.j <- (x.j + x.s.(x.i)) mod 256;
       swap x.s x.i x.j;
       let mask = x.s.((x.s.(x.i) + x.s.(x.j)) mod 256) in
-      dst.[a] <- Char.chr ((Char.code dst.[a]) lxor mask);
+      dst.[a] <- Char.chr ((Char.code (Bytes.get dst a)) lxor mask);
     done;
-    dst
+    Bytes.unsafe_to_string dst
 
 end
 

--- a/src/parser/convert.ml
+++ b/src/parser/convert.ml
@@ -95,10 +95,10 @@ let hexa_digit_of_int (n : int) : char =
 
 let hexa_of_char (c : char) : string =
   let x = Char.code c in
-  let s = "00" in
+  let s = Bytes.unsafe_of_string "00" in
   s.[0] <- hexa_digit_of_int (x / 16);
   s.[1] <- hexa_digit_of_int (x mod 16);
-  s
+  Bytes.unsafe_to_string s
 
 let hexa_of_char_buf (buf : Buffer.t) (c : char) : unit =
   let x = Char.code c in

--- a/src/stream/zlib.ml
+++ b/src/stream/zlib.ml
@@ -61,7 +61,7 @@ module Zlib = struct
       ) else
         try
           let transform = Cryptokit.Zlib.uncompress () in
-          transform#put_substring content 2 (len - 6);
+          transform#put_substring (Bytes.of_string content) 2 (len - 6);
           transform#finish;
           let result = transform#get_string in
 


### PR DESCRIPTION
- Support for safe-string.
- Removed the curses' cmx dependency for it may not be installed with opam.
- Avoid hygiene violations with make test.